### PR TITLE
Blog app - integration specs for views and fix n+1 problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'bootsnap', require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem 'database_cleaner'
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'rspec-rails', '~> 4.0.0.beta2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,12 @@ GEM
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     debug (1.6.2)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
@@ -258,6 +264,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  database_cleaner
   debug
   importmap-rails
   jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.37.1)
       addressable
       matrix
@@ -241,6 +244,7 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
+    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -263,6 +267,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bullet
   capybara
   database_cleaner
   debug

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Cloning a repository
 - Twitter: [@Onenewpage1](https://twitter.com/Onenewpage1)
 - LinkedIn: [fabien brathwaite](https://www.linkedin.com/in/fabien-brathwaite/)
 
+👤 **Dino Quispe**
+
+- GitHub: [@dqarias](https://github.com/dqarias)
+- Twitter: [@DinoRonald7](https://twitter.com/DinoRonald7?t=Zanx9DXMEG9C_PNF3woZFg&s=08)
+- LinkedIn: [Dino Quispe](https://www.linkedin.com/in/dino-ronald-quispe-arias/)
+
+
 ## Show your support
 
 Give a ⭐️ if you like this project!

--- a/README.md
+++ b/README.md
@@ -10,8 +10,16 @@
 - Rails
 
 ## Getting Started
+Install
+- To install necessary gem files in your machine run bundle install on your terminal.
+- To run your machine locally run rails server on your terminal.
 
-### Prerequisites
+- Set up RSpec in your app and create the Spec folder rails g rspec:install
+
+- Run the migration into your testing environment rails db:migrate RAILS_ENV=test
+
+- To see all tests with description run rspec spec --format documentation
+
 #### Setup
 Cloning a repository
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -38,6 +38,6 @@ class PostsController < ApplicationController
   def show
     @specific_post = Post.find(params[:id])
     @user = current_user
-    @comments = @specific_post.comments
+    @comments = Comment.includes(:author).where(post: @specific_post)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,6 +14,6 @@ class Post < ApplicationRecord
   end
 
   def most_recent_comments
-    Comment.where(post: self).order(created_at: :desc).limit(5)
+    Comment.includes(:author).where(post: self).order(created_at: :desc).limit(5)
   end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,8 @@
 <%= render "/users/user" %>
 <%@posts.each do |post| %>
 <div class= "post-preview">
-    <p><%=link_to "Post", user_post_path(@users.id, post.id)%>#<%=post.id%></p>
+    <p>Post #<%=post.id%></p>
+    <h2><%=link_to post.title, user_post_path(@users.id, post.id) %></h2>
     <p><%= post.text %></p>
     Comments: <%= post.comments_counter%>
     Likes: <%= post.likes_counter %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,6 @@
 <div class= "post-preview">
     <p>Post# <%= @specific_post.id %> by <%= @user.name %></p>
+    <h2><%= @specific_post.title %></h2>
     <p>Comments: <%= @specific_post.comments_counter%>, Likes: <%= @specific_post.likes_counter %></p>
     <%= render "likes/new" %>
     <p><%= @specific_post.text %></p>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,6 +8,6 @@
 <div class= newcomment-block>
     <%= render 'comments/new'%>
 </div>
-<%@specific_post.comments.each do |comment|%>
+<%@comments.each do |comment|%>
 <p><%= comment.author.name %>, <%= comment.text %></p>
 <%end%>

--- a/app/views/users/_post.html.erb
+++ b/app/views/users/_post.html.erb
@@ -1,6 +1,7 @@
 <%@specific_user.recent_post.each do |post|%>
 <div class= "post-block">
     Post# <%=post.id%>
+    <h2><%= link_to post.title, user_post_path(@specific_user.id, post.id)%></h2>
     <p><%= post.text%></p>
     Comments: <%= post.comments_counter%>
     Likes: <%= post.likes_counter%>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,5 +1,5 @@
 <div class="user-container">
-    <div class= "img-block"><img src= "https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80"></div>
+    <div class= "img-block"><img src= 'https://i.pravatar.cc/150?img=2'></div>
     <div class= "user-block">
         <h2><%= @specific_user.name %></h2>
         <p>number of posts: <%= @specific_user.posts_counter %></p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,6 @@
 <%@users.each do |user|%>
   <div class="user-container">
-      <div class= "img-block"><img src = "https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80"></div>
+      <div class= "img-block"><img src = 'https://i.pravatar.cc/150?img=2'></div>
       <div class= "user-block">
           <h2><%= link_to user.name, user %></h2>
           <p>number of posts: <%= user.posts_counter%></p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,11 +1,10 @@
-
 <%@users.each do |user|%>
-<div class="user-container">
-    <div class= "img-block"><img src = "https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80"></div>
-    <div class= "user-block">
-        <h2><%= link_to user.name, user %></h2>
-        <p>number of posts: <%= user.posts_counter%></p>
-    </div>
-</div>
-<br>
+  <div class="user-container">
+      <div class= "img-block"><img src = "https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80"></div>
+      <div class= "user-block">
+          <h2><%= link_to user.name, user %></h2>
+          <p>number of posts: <%= user.posts_counter%></p>
+      </div>
+  </div>
+  <br>
 <%end%>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  # config.after_initialize do
+  #   Bullet.enable        = true
+  #   Bullet.bullet_logger = true
+  #   Bullet.raise         = true # raise an error if n+1 query occurs
+  # end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,0 +1,3 @@
+example_id                                       | status | run_time     |
+------------------------------------------------ | ------ | ------------ |
+./spec/views/users/index.html.erb_spec.rb[1:1:1] | failed | 9.26 seconds |

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
-require_relative '../config/environment'
+require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,11 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
+require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'capybara/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -30,6 +31,7 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -61,4 +63,20 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # config.before(:suite) do
+  #   DatabaseCleaner.clean_with(:truncation)
+  # end
+
+  # config.before(:each) do
+  #   DatabaseCleaner.strategy = :transaction
+  # end
+
+  # config.before(:each, js: true) do
+  #   DatabaseCleaner.strategy = :truncation
+  # end
+
+  # This block must be here, do not combine with the other `before(:each)` block.
+  # This makes it so Capybara can see the database.
 end
+Capybara.default_driver = :selenium_chrome

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,38 +51,38 @@ RSpec.configure do |config|
   #   # is tagged with `:focus`, all examples get run. RSpec also provides
   #   # aliases for `it`, `describe`, and `context` that include `:focus`
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
+  # config.filter_run_when_matching :focus
   #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend
   #   # you configure your source control system to ignore this file.
-  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  # config.example_status_persistence_file_path = "spec/examples.txt"
   #
   #   # Limits the available syntax to the non-monkey patched syntax that is
   #   # recommended. For more details, see:
   #   # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
-  #   config.disable_monkey_patching!
+  #     config.disable_monkey_patching!
   #
   #   # Many RSpec users commonly either run the entire suite or an individual
   #   # file, and it's useful to allow more verbose output when running an
   #   # individual spec file.
-  #   if config.files_to_run.one?
+  #     if config.files_to_run.one?
   #     # Use the documentation formatter for detailed output,
   #     # unless a formatter has already been configured
   #     # (e.g. via a command-line flag).
   #     config.default_formatter = "doc"
-  #   end
+  #     end
   #
   #   # Print the 10 slowest examples and example groups at the
   #   # end of the spec run, to help surface which specs are running
   #   # particularly slow.
-  #   config.profile_examples = 10
+  #     config.profile_examples = 10
   #
   #   # Run specs in random order to surface order dependencies. If you find an
   #   # order dependency and want to debug it, you can fix the order by providing
   #   # the seed, which is printed after each run.
   #   #     --seed 1234
-  #   config.order = :random
+  #    config.order = :random
   #
   #   # Seed global randomization in this process using the `--seed` CLI option.
   #   # Setting this allows you to use `--seed` to deterministically reproduce

--- a/spec/views/posts/index.html.erb_spec.rb
+++ b/spec/views/posts/index.html.erb_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'users/show.html.erb', type: :system do
+    describe 'show page' do
+        before do
+            @first_user = User.new(name: 'Fabien', photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80',
+                bio: 'My name is Fabien', posts_counter: 0)
+            @first_post = Post.create(title: 'My first post', text: 'Hi there', comments_counter: 0, likes_counter: 0, author: @first_user)
+            @first_comment = Comment.create(id: 1, text: 'This is a great post', author: @first_user, post: @first_post)
+            Like.create(id: 1, author: @first_user, post: @first_post)
+        end
+
+        it 'shows the user photo, name and post count' do
+            visit user_posts_path(@first_user, @first_post)
+            sleep(3)
+            expect(page).to have_content(@first_user.name)
+            expect(page).to have_content('number of posts: 1')
+            expect(page).to have_content(@first_post.title)
+            expect(page).to have_content(@first_post.text)
+            expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
+        end
+
+
+        it 'shows the post comments, likes count and comments count' do
+            visit user_posts_path(@first_user, @first_post)
+            sleep(3)
+            expect(page).to have_content(@first_comment.text)
+            expect(page).to have_content('Comments: 1')
+            expect(page).to have_content('Likes: 1')
+        end
+
+        it 'shows the post comments, likes count and comments count' do
+            visit user_posts_path(@first_user, @first_post)
+            sleep(3)
+            expect(page).to have_content('Pagination')
+            click_link @first_post.title
+            expect(page).to have_current_path(user_post_path(@first_user, @first_post))
+            sleep(3)
+        end
+    end
+end

--- a/spec/views/posts/index.html.erb_spec.rb
+++ b/spec/views/posts/index.html.erb_spec.rb
@@ -1,41 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe 'users/show.html.erb', type: :system do
-    describe 'show page' do
-        before do
-            @first_user = User.new(name: 'Fabien', photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80',
-                bio: 'My name is Fabien', posts_counter: 0)
-            @first_post = Post.create(title: 'My first post', text: 'Hi there', comments_counter: 0, likes_counter: 0, author: @first_user)
-            @first_comment = Comment.create(id: 1, text: 'This is a great post', author: @first_user, post: @first_post)
-            Like.create(id: 1, author: @first_user, post: @first_post)
-        end
-
-        it 'shows the user photo, name and post count' do
-            visit user_posts_path(@first_user, @first_post)
-            sleep(3)
-            expect(page).to have_content(@first_user.name)
-            expect(page).to have_content('number of posts: 1')
-            expect(page).to have_content(@first_post.title)
-            expect(page).to have_content(@first_post.text)
-            expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
-        end
-
-
-        it 'shows the post comments, likes count and comments count' do
-            visit user_posts_path(@first_user, @first_post)
-            sleep(3)
-            expect(page).to have_content(@first_comment.text)
-            expect(page).to have_content('Comments: 1')
-            expect(page).to have_content('Likes: 1')
-        end
-
-        it 'shows the post comments, likes count and comments count' do
-            visit user_posts_path(@first_user, @first_post)
-            sleep(3)
-            expect(page).to have_content('Pagination')
-            click_link @first_post.title
-            expect(page).to have_current_path(user_post_path(@first_user, @first_post))
-            sleep(3)
-        end
+  describe 'show page' do
+    before do
+      @first_user = User.new(name: 'Fabien', photo: 'https://i.pravatar.cc/150?img=2',
+                             bio: 'My name is Fabien', posts_counter: 0)
+      @first_post = Post.create(title: 'My first post', text: 'Hi there', comments_counter: 0, likes_counter: 0,
+                                author: @first_user)
+      @first_comment = Comment.create(id: 1, text: 'This is a great post', author: @first_user, post: @first_post)
+      Like.create(id: 1, author: @first_user, post: @first_post)
     end
+
+    it 'shows the user photo, name and post count' do
+      visit user_posts_path(@first_user, @first_post)
+      sleep(3)
+      expect(page).to have_content(@first_user.name)
+      expect(page).to have_content('number of posts: 1')
+      expect(page).to have_content(@first_post.title)
+      expect(page).to have_content(@first_post.text)
+      expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
+    end
+
+    it 'shows the post comments, likes count and comments count' do
+      visit user_posts_path(@first_user, @first_post)
+      sleep(3)
+      expect(page).to have_content(@first_comment.text)
+      expect(page).to have_content('Comments: 1')
+      expect(page).to have_content('Likes: 1')
+    end
+
+    it 'shows the post comments, likes count and comments count' do
+      visit user_posts_path(@first_user, @first_post)
+      sleep(3)
+      expect(page).to have_content('Pagination')
+      click_link @first_post.title
+      expect(page).to have_current_path(user_post_path(@first_user, @first_post))
+      sleep(3)
+    end
+  end
 end

--- a/spec/views/posts/index.html.erb_spec.rb
+++ b/spec/views/posts/index.html.erb_spec.rb
@@ -11,28 +11,63 @@ RSpec.describe 'users/show.html.erb', type: :system do
       Like.create(id: 1, author: @first_user, post: @first_post)
     end
 
-    it 'shows the user photo, name and post count' do
+    it 'shows the user photo' do
       visit user_posts_path(@first_user, @first_post)
       sleep(3)
-      expect(page).to have_content(@first_user.name)
-      expect(page).to have_content('number of posts: 1')
-      expect(page).to have_content(@first_post.title)
-      expect(page).to have_content(@first_post.text)
       expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
     end
 
-    it 'shows the post comments, likes count and comments count' do
+    it 'shows the user name' do
+      visit user_posts_path(@first_user, @first_post)
+      sleep(3)
+      expect(page).to have_content(@first_user.name)
+    end
+
+    it 'shows the user post count' do
+      visit user_posts_path(@first_user, @first_post)
+      sleep(3)
+      expect(page).to have_content('number of posts: 1')
+    end
+
+    it 'shows the post title' do
+      visit user_posts_path(@first_user, @first_post)
+      sleep(3)
+      expect(page).to have_content(@first_post.title)
+    end
+
+    it 'shows the post text' do
+      visit user_posts_path(@first_user, @first_post)
+      sleep(3)
+      expect(page).to have_content(@first_post.text)
+    end
+
+    it 'shows the post comments' do
       visit user_posts_path(@first_user, @first_post)
       sleep(3)
       expect(page).to have_content(@first_comment.text)
-      expect(page).to have_content('Comments: 1')
+    end
+
+    it 'shows the post likes count' do
+      visit user_posts_path(@first_user, @first_post)
+      sleep(3)
       expect(page).to have_content('Likes: 1')
     end
 
-    it 'shows the post comments, likes count and comments count' do
+    it 'shows the post comments count' do
+      visit user_posts_path(@first_user, @first_post)
+      sleep(3)
+      expect(page).to have_content('Comments: 1')
+    end
+
+    it 'shows the text on page' do
       visit user_posts_path(@first_user, @first_post)
       sleep(3)
       expect(page).to have_content('Pagination')
+    end
+
+    it 'redirects to user post' do
+      visit user_posts_path(@first_user, @first_post)
+      sleep(3)
       click_link @first_post.title
       expect(page).to have_current_path(user_post_path(@first_user, @first_post))
       sleep(3)

--- a/spec/views/posts/show.html.erb_spec.rb
+++ b/spec/views/posts/show.html.erb_spec.rb
@@ -1,37 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe 'users/show.html.erb', type: :system do
-    describe 'show page' do
-        before do
-            @first_user = User.new(name: 'Fabien', photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80',
-                bio: 'My name is Fabien', posts_counter: 0)
-            @second_user = User.new(name: 'Dino', photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80',
-                bio: 'My name is Dino', posts_counter: 0)
-            @first_post = Post.create(title: 'My first post', text: 'Hi there', comments_counter: 0, likes_counter: 0, author: @first_user)
-            @first_comment = Comment.create(id: 1, text: 'This is a great post', author: @first_user, post: @first_post)
-            Like.create(id: 1, author: @first_user, post: @first_post)
-            @second_comment = Comment.create(id: 2, text: 'This is a second great post', author: @second_user, post: @first_post)
-           
-        end
-
-        it 'shows post title, post author, comments_count, likes_count' do
-            visit user_post_path(@first_user, @first_post)
-            sleep(3)
-            expect(page).to have_content(@first_post.title)
-            expect(page).to have_content(@first_post.author.name)
-            expect(page).to have_content("Comments: #{@first_post.comments_counter}")
-            expect(page).to have_content("Likes: #{@first_post.likes_counter}")
-        end
-
-        it 'shows post body, username of each commentor and comments' do
-            visit user_post_path(@first_user, @first_post)
-            sleep(3)
-            expect(page).to have_content(@first_post.text)
-            expect(page).to have_content(@first_comment.author.name)
-            expect(page).to have_content(@second_comment.author.name)
-            expect(page).to have_content(@first_comment.text)
-            expect(page).to have_content(@second_comment.text)
-        end
-
+  describe 'show page' do
+    before do
+      @first_user = User.new(name: 'Fabien', photo: 'https://i.pravatar.cc/150?img=2',
+                             bio: 'My name is Fabien', posts_counter: 0)
+      @second_user = User.new(name: 'Dino', photo: 'https://i.pravatar.cc/150?img=3',
+                              bio: 'My name is Dino', posts_counter: 0)
+      @first_post = Post.create(title: 'My first post', text: 'Hi there', comments_counter: 0, likes_counter: 0,
+                                author: @first_user)
+      @first_comment = Comment.create(id: 1, text: 'This is a great post', author: @first_user, post: @first_post)
+      Like.create(id: 1, author: @first_user, post: @first_post)
+      @second_comment = Comment.create(id: 2, text: 'This is a second great post', author: @second_user,
+                                       post: @first_post)
     end
+
+    it 'shows post title, post author, comments_count, likes_count' do
+      visit user_post_path(@first_user, @first_post)
+      sleep(3)
+      expect(page).to have_content(@first_post.title)
+      expect(page).to have_content(@first_post.author.name)
+      expect(page).to have_content("Comments: #{@first_post.comments_counter}")
+      expect(page).to have_content("Likes: #{@first_post.likes_counter}")
+    end
+
+    it 'shows post body, username of each commentor and comments' do
+      visit user_post_path(@first_user, @first_post)
+      sleep(3)
+      expect(page).to have_content(@first_post.text)
+      expect(page).to have_content(@first_comment.author.name)
+      expect(page).to have_content(@second_comment.author.name)
+      expect(page).to have_content(@first_comment.text)
+      expect(page).to have_content(@second_comment.text)
+    end
+  end
 end

--- a/spec/views/posts/show.html.erb_spec.rb
+++ b/spec/views/posts/show.html.erb_spec.rb
@@ -5,9 +5,13 @@ RSpec.describe 'users/show.html.erb', type: :system do
         before do
             @first_user = User.new(name: 'Fabien', photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80',
                 bio: 'My name is Fabien', posts_counter: 0)
+            @second_user = User.new(name: 'Dino', photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80',
+                bio: 'My name is Dino', posts_counter: 0)
             @first_post = Post.create(title: 'My first post', text: 'Hi there', comments_counter: 0, likes_counter: 0, author: @first_user)
             @first_comment = Comment.create(id: 1, text: 'This is a great post', author: @first_user, post: @first_post)
             Like.create(id: 1, author: @first_user, post: @first_post)
+            @second_comment = Comment.create(id: 2, text: 'This is a second great post', author: @second_user, post: @first_post)
+           
         end
 
         it 'shows post title, post author, comments_count, likes_count' do
@@ -18,5 +22,16 @@ RSpec.describe 'users/show.html.erb', type: :system do
             expect(page).to have_content("Comments: #{@first_post.comments_counter}")
             expect(page).to have_content("Likes: #{@first_post.likes_counter}")
         end
+
+        it 'shows post body, username of each commentor and comments' do
+            visit user_post_path(@first_user, @first_post)
+            sleep(3)
+            expect(page).to have_content(@first_post.text)
+            expect(page).to have_content(@first_comment.author.name)
+            expect(page).to have_content(@second_comment.author.name)
+            expect(page).to have_content(@first_comment.text)
+            expect(page).to have_content(@second_comment.text)
+        end
+
     end
 end

--- a/spec/views/posts/show.html.erb_spec.rb
+++ b/spec/views/posts/show.html.erb_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'users/show.html.erb', type: :system do
+    describe 'show page' do
+        before do
+            @first_user = User.new(name: 'Fabien', photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80',
+                bio: 'My name is Fabien', posts_counter: 0)
+            @first_post = Post.create(title: 'My first post', text: 'Hi there', comments_counter: 0, likes_counter: 0, author: @first_user)
+            @first_comment = Comment.create(id: 1, text: 'This is a great post', author: @first_user, post: @first_post)
+            Like.create(id: 1, author: @first_user, post: @first_post)
+        end
+    end
+end

--- a/spec/views/posts/show.html.erb_spec.rb
+++ b/spec/views/posts/show.html.erb_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe 'users/show.html.erb', type: :system do
         end
 
         it 'shows post title, post author, comments_count, likes_count' do
-            visit user_posts_path(@first_user, @first_post)
+            visit user_post_path(@first_user, @first_post)
             sleep(3)
             expect(page).to have_content(@first_post.title)
-            expect(page).to have_content(@first_post.author)
-            expect(page).to have_content("Comments: #{first_post.comments_counter}")
-            expect(page).to have_content("Likes: #{first_post.likes_counter}")
+            expect(page).to have_content(@first_post.author.name)
+            expect(page).to have_content("Comments: #{@first_post.comments_counter}")
+            expect(page).to have_content("Likes: #{@first_post.likes_counter}")
         end
     end
 end

--- a/spec/views/posts/show.html.erb_spec.rb
+++ b/spec/views/posts/show.html.erb_spec.rb
@@ -9,5 +9,14 @@ RSpec.describe 'users/show.html.erb', type: :system do
             @first_comment = Comment.create(id: 1, text: 'This is a great post', author: @first_user, post: @first_post)
             Like.create(id: 1, author: @first_user, post: @first_post)
         end
+
+        it 'shows post title, post author, comments_count, likes_count' do
+            visit user_posts_path(@first_user, @first_post)
+            sleep(3)
+            expect(page).to have_content(@first_post.title)
+            expect(page).to have_content(@first_post.author)
+            expect(page).to have_content("Comments: #{first_post.comments_counter}")
+            expect(page).to have_content("Likes: #{first_post.likes_counter}")
+        end
     end
 end

--- a/spec/views/posts/show.html.erb_spec.rb
+++ b/spec/views/posts/show.html.erb_spec.rb
@@ -15,21 +15,46 @@ RSpec.describe 'users/show.html.erb', type: :system do
                                        post: @first_post)
     end
 
-    it 'shows post title, post author, comments_count, likes_count' do
+    it 'shows post title' do
       visit user_post_path(@first_user, @first_post)
       sleep(3)
       expect(page).to have_content(@first_post.title)
+    end
+
+    it 'shows post author' do
+      visit user_post_path(@first_user, @first_post)
+      sleep(3)
       expect(page).to have_content(@first_post.author.name)
+    end
+
+    it 'shows post comments_count' do
+      visit user_post_path(@first_user, @first_post)
+      sleep(3)
       expect(page).to have_content("Comments: #{@first_post.comments_counter}")
+    end
+
+    it 'shows post likes_count' do
+      visit user_post_path(@first_user, @first_post)
+      sleep(3)
       expect(page).to have_content("Likes: #{@first_post.likes_counter}")
     end
 
-    it 'shows post body, username of each commentor and comments' do
+    it 'shows post body' do
       visit user_post_path(@first_user, @first_post)
       sleep(3)
       expect(page).to have_content(@first_post.text)
+    end
+
+    it 'shows username of each commentor' do
+      visit user_post_path(@first_user, @first_post)
+      sleep(3)
       expect(page).to have_content(@first_comment.author.name)
       expect(page).to have_content(@second_comment.author.name)
+    end
+
+    it 'shows comments of each commentor' do
+      visit user_post_path(@first_user, @first_post)
+      sleep(3)
       expect(page).to have_content(@first_comment.text)
       expect(page).to have_content(@second_comment.text)
     end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'users/index.html.erb', type: :system do
+  describe 'index page' do
+    before do
+      @first_user = User.create(name: 'Fabien',
+                                photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80', bio: 'Teacher from Mexico', posts_counter: 5)
+      @second_user = User.create(name: 'Richard',
+                                 photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80', bio: 'Teacher from Barbados', posts_counter: 3)
+      @third_user = User.create(name: 'Sheena',
+                                photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80', bio: 'Teacher from Canada', posts_counter: 1)
+    end
+    it 'shows the user name' do
+      visit users_path
+      sleep(5)
+      expect(page).to have_content(@first_user.name)
+      expect(page).to have_content(@second_user.name)
+      expect(page).to have_content(@third_user.name)
+    end
+
+    it 'shows the user photo' do
+      visit users_path
+      sleep(5)
+      expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
+      expect(page).to have_xpath("//img[contains(@src,'#{@second_user.photo}')]")
+      expect(page).to have_xpath("//img[contains(@src,'#{@third_user.photo}')]")
+    end
+
+    it 'shows the user post count' do
+      visit users_path
+      sleep(5)
+      expect(page).to have_content('number of posts: 5')
+      expect(page).to have_content('number of posts: 3')
+      expect(page).to have_content('number of posts: 1')
+    end
+  end
+end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'users/index.html.erb', type: :system do
+RSpec.describe 'users/index.html.erb', type: :feature do
   describe 'index page' do
     before do
       @first_user = User.create(name: 'Fabien',
@@ -10,17 +10,12 @@ RSpec.describe 'users/index.html.erb', type: :system do
       @third_user = User.create(name: 'Sheena',
                                 photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80', bio: 'Teacher from Canada', posts_counter: 1)
     end
-    it 'shows the user name' do
+    it 'show the user name and show the user photo' do
       visit users_path
-      sleep(5)
+      sleep(6)
       expect(page).to have_content(@first_user.name)
       expect(page).to have_content(@second_user.name)
       expect(page).to have_content(@third_user.name)
-    end
-
-    it 'shows the user photo' do
-      visit users_path
-      sleep(5)
       expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
       expect(page).to have_xpath("//img[contains(@src,'#{@second_user.photo}')]")
       expect(page).to have_xpath("//img[contains(@src,'#{@third_user.photo}')]")
@@ -28,10 +23,18 @@ RSpec.describe 'users/index.html.erb', type: :system do
 
     it 'shows the user post count' do
       visit users_path
-      sleep(5)
+      sleep(3)
       expect(page).to have_content('number of posts: 5')
       expect(page).to have_content('number of posts: 3')
       expect(page).to have_content('number of posts: 1')
+    end
+
+    it 'redirect to user/show page' do
+      visit users_path
+      sleep(3)
+      click_link @first_user.name
+      expect(page).to have_current_path(user_path(@first_user))
+      sleep(3)
     end
   end
 end

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -10,12 +10,17 @@ RSpec.describe 'users/index.html.erb', type: :feature do
       @third_user = User.create(name: 'Sheena',
                                 photo: 'https://i.pravatar.cc/150?img=2', bio: 'Teacher from Canada', posts_counter: 1)
     end
-    it 'show the user name and show the user photo' do
+    it 'show the user name' do
       visit users_path
       sleep(6)
       expect(page).to have_content(@first_user.name)
       expect(page).to have_content(@second_user.name)
       expect(page).to have_content(@third_user.name)
+    end
+
+    it 'show the user photo' do
+      visit users_path
+      sleep(4)
       expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
       expect(page).to have_xpath("//img[contains(@src,'#{@second_user.photo}')]")
       expect(page).to have_xpath("//img[contains(@src,'#{@third_user.photo}')]")

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe 'users/index.html.erb', type: :feature do
   describe 'index page' do
     before do
       @first_user = User.create(name: 'Fabien',
-                                photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80', bio: 'Teacher from Mexico', posts_counter: 5)
+                                photo: 'https://i.pravatar.cc/150?img=2', bio: 'Teacher from Mexico', posts_counter: 5)
       @second_user = User.create(name: 'Richard',
-                                 photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80', bio: 'Teacher from Barbados', posts_counter: 3)
+                                 photo: 'https://i.pravatar.cc/150?img=2', bio: 'Teacher from Bar', posts_counter: 3)
       @third_user = User.create(name: 'Sheena',
-                                photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80', bio: 'Teacher from Canada', posts_counter: 1)
+                                photo: 'https://i.pravatar.cc/150?img=2', bio: 'Teacher from Canada', posts_counter: 1)
     end
     it 'show the user name and show the user photo' do
       visit users_path

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -1,0 +1,1 @@
+require 'rails_helper'

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -1,1 +1,44 @@
 require 'rails_helper'
+
+RSpec.describe 'users/show.html.erb', type: :system do
+    describe 'show page' do
+        before do
+            @first_user = User.new(name: 'Fabien', photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80',
+                bio: 'My name is Fabien', posts_counter: 0)
+            @first_post = Post.create(title: 'My first post', text: 'Hi there', comments_counter: 0, likes_counter: 0, author: @first_user)
+            @second_post = Post.create(title: 'My second post', text: 'Yoooooo', comments_counter: 0, likes_counter: 0, author: @first_user)
+            @third_post = Post.create(title: 'My third post', text: 'It is raining today', comments_counter: 0, likes_counter: 0, author: @first_user)
+        end
+        it 'shows the user photo, name, post count and bio' do
+            visit user_path(@first_user)
+            sleep(3)
+            expect(page).to have_content(@first_user.name)
+            expect(page).to have_content('number of posts: 3')
+            expect(page).to have_content(@first_user.bio)
+            expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
+        end
+
+        it 'shows the user recent posts' do
+            visit user_path(@first_user)
+            sleep(3)
+            expect(@first_user.recent_post.length).to eql 3
+        end
+
+        it 'shows the see all post button and redirects to the post index page' do
+            visit user_path(@first_user)
+            sleep(3)
+            expect(page).to have_link("See all posts")
+            click_link "See all posts"
+            expect(page).to have_current_path(user_posts_path(@first_user))
+            sleep(4)
+        end
+
+        it 'redirects to the post show page' do
+            visit user_path(@first_user)
+            sleep(3)
+            click_link @third_post.title
+            expect(page).to have_current_path(user_post_path(@first_user, @third_post))
+            sleep(3)
+        end
+    end
+end

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -1,44 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe 'users/show.html.erb', type: :system do
-    describe 'show page' do
-        before do
-            @first_user = User.new(name: 'Fabien', photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80',
-                bio: 'My name is Fabien', posts_counter: 0)
-            @first_post = Post.create(title: 'My first post', text: 'Hi there', comments_counter: 0, likes_counter: 0, author: @first_user)
-            @second_post = Post.create(title: 'My second post', text: 'Yoooooo', comments_counter: 0, likes_counter: 0, author: @first_user)
-            @third_post = Post.create(title: 'My third post', text: 'It is raining today', comments_counter: 0, likes_counter: 0, author: @first_user)
-        end
-        it 'shows the user photo, name, post count and bio' do
-            visit user_path(@first_user)
-            sleep(3)
-            expect(page).to have_content(@first_user.name)
-            expect(page).to have_content('number of posts: 3')
-            expect(page).to have_content(@first_user.bio)
-            expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
-        end
-
-        it 'shows the user recent posts' do
-            visit user_path(@first_user)
-            sleep(3)
-            expect(@first_user.recent_post.length).to eql 3
-        end
-
-        it 'shows the see all post button and redirects to the post index page' do
-            visit user_path(@first_user)
-            sleep(3)
-            expect(page).to have_link("See all posts")
-            click_link "See all posts"
-            expect(page).to have_current_path(user_posts_path(@first_user))
-            sleep(4)
-        end
-
-        it 'redirects to the post show page' do
-            visit user_path(@first_user)
-            sleep(3)
-            click_link @third_post.title
-            expect(page).to have_current_path(user_post_path(@first_user, @third_post))
-            sleep(3)
-        end
+  describe 'show page' do
+    before do
+      @first_user = User.new(name: 'Fabien', photo: 'https://i.pravatar.cc/150?img=2',
+                             bio: 'My name is Fabien', posts_counter: 0)
+      @first_post = Post.create(title: 'My first post', text: 'Hi there', comments_counter: 0, likes_counter: 0,
+                                author: @first_user)
+      @second_post = Post.create(title: 'My second post', text: 'Yoooooo', comments_counter: 0, likes_counter: 0,
+                                 author: @first_user)
+      @third_post = Post.create(title: 'My third post', text: 'It is raining today', comments_counter: 0,
+                                likes_counter: 0, author: @first_user)
     end
+    it 'shows the user photo, name, post count and bio' do
+      visit user_path(@first_user)
+      sleep(3)
+      expect(page).to have_content(@first_user.name)
+      expect(page).to have_content('number of posts: 3')
+      expect(page).to have_content(@first_user.bio)
+      expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
+    end
+
+    it 'shows the user recent posts' do
+      visit user_path(@first_user)
+      sleep(3)
+      expect(@first_user.recent_post.length).to eql 3
+    end
+
+    it 'shows the see all post button and redirects to the post index page' do
+      visit user_path(@first_user)
+      sleep(3)
+      expect(page).to have_link('See all posts')
+      click_link 'See all posts'
+      expect(page).to have_current_path(user_posts_path(@first_user))
+      sleep(4)
+    end
+
+    it 'redirects to the post show page' do
+      visit user_path(@first_user)
+      sleep(3)
+      click_link @third_post.title
+      expect(page).to have_current_path(user_post_path(@first_user, @third_post))
+      sleep(3)
+    end
+  end
 end

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -12,13 +12,28 @@ RSpec.describe 'users/show.html.erb', type: :system do
       @third_post = Post.create(title: 'My third post', text: 'It is raining today', comments_counter: 0,
                                 likes_counter: 0, author: @first_user)
     end
-    it 'shows the user photo, name, post count and bio' do
+    it 'shows the user photo' do
+      visit user_path(@first_user)
+      sleep(3)
+      expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
+    end
+
+    it 'shows the user name' do
       visit user_path(@first_user)
       sleep(3)
       expect(page).to have_content(@first_user.name)
+    end
+
+    it 'shows the user post count' do
+      visit user_path(@first_user)
+      sleep(3)
       expect(page).to have_content('number of posts: 3')
+    end
+
+    it 'shows the user bio' do
+      visit user_path(@first_user)
+      sleep(3)
       expect(page).to have_content(@first_user.bio)
-      expect(page).to have_xpath("//img[contains(@src,'#{@first_user.photo}')]")
     end
 
     it 'shows the user recent posts' do
@@ -27,13 +42,18 @@ RSpec.describe 'users/show.html.erb', type: :system do
       expect(@first_user.recent_post.length).to eql 3
     end
 
-    it 'shows the see all post button and redirects to the post index page' do
+    it 'shows the see all post button' do
       visit user_path(@first_user)
       sleep(3)
       expect(page).to have_link('See all posts')
+    end
+
+    it 'redirects to the post index page' do
+      visit user_path(@first_user)
+      sleep(3)
       click_link 'See all posts'
       expect(page).to have_current_path(user_posts_path(@first_user))
-      sleep(4)
+      sleep(3)
     end
 
     it 'redirects to the post show page' do


### PR DESCRIPTION
Make sure that the N+1 problem is solved when fetching all posts and their comments for a user. 
Integration specs
- Use Capybara to write integration tests for each view in your project.

User index page:

- I can see the username of all other users.
- I can see the profile picture for each user.
- I can see the number of posts each user has written.
- When I click on a user, I am redirected to that user's show page.

User show page:
- I can see the user's profile picture.
- I can see the user's username.
- I can see the number of posts the user has written.
- I can see the user's bio.
- I can see the user's first 3 posts.
- I can see a button that lets me view all of a user's posts.
- When I click a user's post, it redirects me to that post's show page.
- When I click to see all posts, it redirects me to the user's post's index page.

User post index page:
- I can see the user's profile picture.
- I can see the user's username.
- I can see the number of posts the user has written.
- I can see a post's title.
- I can see some of the post's body.
- I can see the first comments on a post.
- I can see how many comments a post has.
- I can see how many likes a post has.
- I can see a section for pagination if there are more posts than fit on the view.
- When I click on a post, it redirects me to that post's show page.

Post show page:
- I can see the post's title.
-  can see who wrote the post.
- I can see how many comments it has.
- I can see how many likes it has.
- I can see the post body.
- I can see the username of each commentor.
- I can see the comment each commentor left.